### PR TITLE
Another proposed fix for weak_reference

### DIFF
--- a/db_handler.py
+++ b/db_handler.py
@@ -16,7 +16,7 @@ class Db_interface:
             password=str(config("db_password")),
             database=str(config("db_name"))
         )
-        self.cursor = self.db.cursor()
+        self.cursor = self.db.cursor(buffered=True)
 
     def reconnect(self) -> None:
         self.db.disconnect()
@@ -26,14 +26,14 @@ class Db_interface:
             password=str(config("db_password")),
             database=str(config("db_name"))
         )
-        self.cursor = self.db.cursor()
+        self.cursor = self.db.cursor(buffered=True)
 
-    def stat_execute(self, func, sql: str, adr: tuple = ()) -> None:
-        self.reconnect()
+    def stat_execute(self, sql_str: str, adr: tuple = ()) -> None:
         ok = False
         while not ok:
             try:
-                func(sql, adr)
+                self.cursor.execute(sql_str, adr)
+                self.db.commit()
                 ok = True
             except OperationalError:
                 self.reconnect()

--- a/db_handler.py
+++ b/db_handler.py
@@ -40,7 +40,7 @@ class Db_interface:
                 continue
 
     def status(self):
-        self.stat_execute(self.cursor.execute, "SHOW TABLES")
+        self.stat_execute("SHOW TABLES")
         return self.cursor.fetchall()
 
     def add_app(self, user_id, role_id, message_id, app_id=0):
@@ -48,26 +48,24 @@ class Db_interface:
             app_id = self.new_id()
         elif not self.check_id_free(app_id):
             raise Exception("App ID already exists!")
-        self.stat_execute(self.cursor.execute, "INSERT INTO Application (id,member_id,role,message_id) VALUES (%s, %s, %s, %s)",
-                          (app_id, user_id, role_id, message_id,))
-        self.db.commit()
+        self.stat_execute("INSERT INTO Application (id,member_id,role,message_id) VALUES (%s, %s, %s, %s)", (app_id, user_id, role_id, message_id,))
         return app_id
 
-    def is_member(self, id):
-        self.stat_execute(self.cursor.execute,
-                          "SELECT null FROM Member WHERE id = %s", (id,))
+    def is_member(self, user_id):
+        self.stat_execute("SELECT null FROM Member WHERE id = %s", (user_id,))
         return len(self.cursor.fetchall()) == 1
 
-    def count_app(self, id, role=None):
-        self.sql = ""
-        self.adr = ""
-        if role == None:
-            self.sql = "SELECT null FROM Application WHERE member_id = %s"
-            self.adr = (id,)
+    def count_app(self, user_id, role=None):
+        sql_str = ""
+        adr = ""
+        if role is None:
+            sql_str = "SELECT null FROM Application WHERE member_id = %s"
+            adr = (user_id,)
         else:
-            self.sql = "SELECT null FROM Application WHERE member_id = %s AND role = %s"
-            self.adr = (id, role,)
-        self.stat_execute(self.cursor.execute, self.sql, self.adr)
+            sql_str = "SELECT null FROM Application WHERE member_id = %s AND role = %s"
+            adr = (user_id, role)
+
+        self.stat_execute(sql_str, adr)
         return len(self.cursor.fetchall())
 
     def new_id(self):
@@ -83,13 +81,11 @@ class Db_interface:
 
     def check_id_free(self, app_id):
         # check if id already exist
-        self.stat_execute(
-            self.cursor.execute, "SELECT null FROM Application WHERE id = %s", (app_id,))
+        self.stat_execute("SELECT null FROM Application WHERE id = %s", (app_id,))
         return len(self.cursor.fetchall()) == 0
 
     def check_vote(self, app_id):
-        self.stat_execute(
-            self.cursor.execute, "SELECT is_in_favor FROM app_vote WHERE app_id = %s", (app_id,))
+        self.stat_execute("SELECT is_in_favor FROM app_vote WHERE app_id = %s", (app_id,))
         count_in_favor = 0
         count_against = 0
         for (vote,) in self.cursor:
@@ -100,32 +96,27 @@ class Db_interface:
         return {"in_favor": count_in_favor, "against": count_against}
 
     def has_voted(self, app_id, voter_id):
-        self.stat_execute(
-            self.cursor.execute, "SELECT null FROM app_vote WHERE app_id = %s AND voter_id = %s ", (app_id, voter_id,))
+        self.stat_execute("SELECT null FROM app_vote WHERE app_id = %s AND voter_id = %s ", (app_id, voter_id,))
         return len(self.cursor.fetchall()) == 1
 
     def vote_for(self, app_id, voter_id, is_in_favor):
-        self.sql = ""
-        self.adr = None
+        sql_str = ""
+        adr = None
         has_voted = self.has_voted(app_id, voter_id)
         if not has_voted:
-            self.sql = "INSERT INTO app_vote (app_id,voter_id,is_in_favor) VALUES (%s, %s, %s)"
-            self.adr = (app_id, voter_id, is_in_favor,)
+            sql_str = "INSERT INTO app_vote (app_id,voter_id,is_in_favor) VALUES (%s, %s, %s)"
+            adr = (app_id, voter_id, is_in_favor,)
         else:
-            self.sql = "UPDATE app_vote SET is_in_favor=%s WHERE app_id = %s AND voter_id = %s"
-            self.adr = (is_in_favor, app_id, voter_id,)
-        self.stat_execute(self.cursor.execute, self.sql, self.adr)
-        self.db.commit()
+            sql_str = "UPDATE app_vote SET is_in_favor=%s WHERE app_id = %s AND voter_id = %s"
+            adr = (is_in_favor, app_id, voter_id,)
+        self.stat_execute(sql_str, adr)
         return has_voted
 
     def del_app(self, app_id):
-        self.stat_execute(
-            self.cursor.execute, "DELETE Application,app_vote FROM Application LEFT JOIN app_vote ON Application.id = app_vote.app_id WHERE id = %s", (app_id,))
-        self.db.commit()
+        self.stat_execute("DELETE Application,app_vote FROM Application LEFT JOIN app_vote ON Application.id = app_vote.app_id WHERE id = %s", (app_id,))
 
     def get_app(self, app_id):
-        self.stat_execute(
-            self.cursor.execute, "SELECT member_id, role, message_id FROM Application WHERE id = %s", (app_id,))
+        self.stat_execute("SELECT member_id, role, message_id FROM Application WHERE id = %s", (app_id,))
         for (member_id, role, message_id) in self.cursor:
             return {"member_id": member_id, "role": role, "message_id": message_id}
 


### PR DESCRIPTION
This pull request brings the following with it:

- The database cursor will now buffer instead of lazily loading values,
- stat_execute will now directly call `self.cursor.execute()` instead of passing it in as a function,
- All calls to `self.db.commit()` have been removed in favour of calling it in `stat_execute()`,
- Changed the `sql` and `atr` locals back to being confined to their method, they exist long enough for `stat_execute()` to work,
- Renamed all `sql` variables to `sql_str` and `id` values to `user_id`

Closes #10 